### PR TITLE
Patch: update script (making it useable again) and some test cases

### DIFF
--- a/arksearch/arksearch.py
+++ b/arksearch/arksearch.py
@@ -81,7 +81,6 @@ def quick_search(search_term):
         'User-Agent': USER_AGENT,
     }
     r = requests.get(url.format(search_term, headers=headers))
-    print(r.text)
     return r.json()
 
 

--- a/tests/json_data/multiple_results.json
+++ b/tests/json_data/multiple_results.json
@@ -1,1 +1,21 @@
-[{"id":"88174","label":"<div class=\"l badge\"><img src=\"http://www.intel.com/content/dam/www/global/ark/badges/41492_128.gif/jcr:content/renditions/_48.gif\" alt=\"Intel® Xeon® Logo Logo\" onload=\"$(this).show();\" style=\"display: none;\" /></div><div class=\"l text\">Intel® Xeon® Processor E3-1270 v5 <br />(8M Cache, 3.60 GHz)</div><div class=\"c\"></div>","value":"Intel® Xeon® Processor E3-1270 v5 (8M Cache, 3.60 GHz)","category":"product","quickUrl":"/products/88174/Intel-Xeon-Processor-E3-1270-v5-8M-Cache-3_60-GHz"},{"id":"75056","label":"<div class=\"l badge\"><img src=\"http://www.intel.com/content/dam/www/global/ark/badges/77416_128.gif/jcr:content/renditions/_48.gif\" alt=\"Intel® Xeon® v2 Logo Logo\" onload=\"$(this).show();\" style=\"display: none;\" /></div><div class=\"l text\">Intel® Xeon® Processor E3-1270 v3 <br />(8M Cache, 3.50 GHz)</div><div class=\"c\"></div>","value":"Intel® Xeon® Processor E3-1270 v3 (8M Cache, 3.50 GHz)","category":"product","quickUrl":"/products/75056/Intel-Xeon-Processor-E3-1270-v3-8M-Cache-3_50-GHz"},{"id":"65727","label":"<div class=\"l badge\"><img src=\"http://www.intel.com/content/dam/www/global/ark/badges/77416_128.gif/jcr:content/renditions/_48.gif\" alt=\"Intel® Xeon® v2 Logo Logo\" onload=\"$(this).show();\" style=\"display: none;\" /></div><div class=\"l text\">Intel® Xeon® Processor E3-1270 v2 <br />(8M Cache, 3.50 GHz)</div><div class=\"c\"></div>","value":"Intel® Xeon® Processor E3-1270 v2 (8M Cache, 3.50 GHz)","category":"product","quickUrl":"/products/65727/Intel-Xeon-Processor-E3-1270-v2-8M-Cache-3_50-GHz"},{"id":"52276","label":"<div class=\"l badge\"><img src=\"http://www.intel.com/content/dam/www/global/ark/badges/41492_128.gif/jcr:content/renditions/_48.gif\" alt=\"Intel® Xeon® Logo Logo\" onload=\"$(this).show();\" style=\"display: none;\" /></div><div class=\"l text\">Intel® Xeon® Processor E3-1270 <br />(8M Cache, 3.40 GHz)</div><div class=\"c\"></div>","value":"Intel® Xeon® Processor E3-1270 (8M Cache, 3.40 GHz)","category":"product","quickUrl":"/products/52276/Intel-Xeon-Processor-E3-1270-8M-Cache-3_40-GHz"}]
+[{
+        "prodUrl": "\/content\/www\/us\/en\/ark\/products\/97479\/intel-xeon-processor-e3-1270-v6-8m-cache-3-80-ghz.html",
+        "label": "Intel® Xeon® Processor E3-1270 v6 (8M Cache, 3.80 GHz)"
+    },
+    {
+        "prodUrl": "\/content\/www\/us\/en\/ark\/products\/88174\/intel-xeon-processor-e3-1270-v5-8m-cache-3-60-ghz.html",
+        "label": "Intel® Xeon® Processor E3-1270 v5 (8M Cache, 3.60 GHz)"
+    },
+    {
+        "prodUrl": "\/content\/www\/us\/en\/ark\/products\/75056\/intel-xeon-processor-e3-1270-v3-8m-cache-3-50-ghz.html",
+        "label": "Intel® Xeon® Processor E3-1270 v3 (8M Cache, 3.50 GHz)"
+    },
+    {
+        "prodUrl": "\/content\/www\/us\/en\/ark\/products\/65727\/intel-xeon-processor-e3-1270-v2-8m-cache-3-50-ghz.html",
+        "label": "Intel® Xeon® Processor E3-1270 v2 (8M Cache, 3.50 GHz)"
+    },
+    {
+        "prodUrl": "\/content\/www\/us\/en\/ark\/products\/52276\/intel-xeon-processor-e3-1270-8m-cache-3-40-ghz.html",
+        "label": "Intel® Xeon® Processor E3-1270 (8M Cache, 3.40 GHz)"
+    }
+]

--- a/tests/json_data/single_result.json
+++ b/tests/json_data/single_result.json
@@ -1,1 +1,4 @@
-[{"id":"75053","label":"<div class=\"l badge\"><img src=\"http://www.intel.com/content/dam/www/global/ark/badges/77416_128.gif/jcr:content/renditions/_48.gif\" alt=\"Intel® Xeon® v2 Logo Logo\" onload=\"$(this).show();\" style=\"display: none;\" /></div><div class=\"l text\">Intel® Xeon® Processor E3-1230L v3 <br />(8M Cache, 1.80 GHz)</div><div class=\"c\"></div>","value":"Intel® Xeon® Processor E3-1230L v3 (8M Cache, 1.80 GHz)","category":"product","quickUrl":"/products/75053/Intel-Xeon-Processor-E3-1230L-v3-8M-Cache-1_80-GHz"}]
+[{
+    "prodUrl": "\/content\/www\/us\/en\/ark\/products\/75053\/intel-xeon-processor-e3-1230l-v3-8m-cache-1-80-ghz.html",
+    "label": "Intel® Xeon® Processor E3-1230L v3 (8M Cache, 1.80 GHz)"
+}]

--- a/tests/test_arksearch.py
+++ b/tests/test_arksearch.py
@@ -22,31 +22,31 @@ class TestArksearch(object):
                   '</tr>')
 
     test_table_tcase = (
-                  '<table class="specs infoTable"><tr class="infoSection">'
-                  '<tr id="TCase" class="tech">'
-                  '<td class="lc">'
-                  '<span class="tooltippable">T<sub>CASE</sub></span>'
-                  '</td>'
-                  '<td class="rc">66.8</td>'
-                  '</tr>')
+        '<table class="specs infoTable"><tr class="infoSection">'
+        '<tr id="TCase" class="tech">'
+        '<td class="lc">'
+        '<span class="tooltippable">T<sub>CASE</sub></span>'
+        '</td>'
+        '<td class="rc">66.8</td>'
+        '</tr>')
 
     test_table_newline = (
-                  '<table class="specs infoTable"><tr class="infoSection">'
-                  '<tr id="GraphicsModel" data-disclaim="GraphicsModel">'
-                  '<td class="lc">'
-                  '<span>Processor Graphics <small><sup>\xe2</sup></small>'
-                  '</span>'
-                  '</td>'
-                  '<td class="rc">None</td>'
-                  '</tr>')
+        '<table class="specs infoTable"><tr class="infoSection">'
+        '<tr id="GraphicsModel" data-disclaim="GraphicsModel">'
+        '<td class="lc">'
+        '<span>Processor Graphics <small><sup>\xe2</sup></small>'
+        '</span>'
+        '</td>'
+        '<td class="rc">None</td>'
+        '</tr>')
 
     def test_get_full_ark_url(self):
-        quickurl = ("/products/82930/Intel-Core-i7-5960X-Processor-Extreme-"
-                    "Edition-20M-Cache-up-to-3_50-GHz")
-        result = arksearch.get_full_ark_url(quickurl)
-        expected_url = ("http://ark.intel.com/products/82930/Intel-Core-i7-"
-                        "5960X-Processor-Extreme-Edition-20M-Cache-up-to-"
-                        "3_50-GHz")
+        prodUrl = (
+            "\/content\/www\/us\/en\/ark\/products\/82930\/intel-core-i7-5960x-processor-extreme-edition-20m-cache-up-to-3-50-ghz.html")
+        result = arksearch.get_full_ark_url(prodUrl)
+        expected_url = ("http://ark.intel.com/"
+                        "content/www/us/en/ark/products/"
+                        "82930/intel-core-i7-5960x-processor-extreme-edition-20m-cache-up-to-3-50-ghz.html")
         assert result == expected_url
 
     def test_get_cpu_html(self,):
@@ -56,9 +56,9 @@ class TestArksearch(object):
             return response(200, self.test_table.encode('utf-8'))
 
         with HTTMock(ark_mock):
-            quickurl = ("/products/82930/Intel-Core-i7-5960X-Processor-"
-                        "Extreme-Edition-20M-Cache-up-to-3_50-GHz")
-            result = arksearch.get_cpu_html(quickurl)
+            prodUrl = (
+                "\/content\/www\/us\/en\/ark\/products\/82930\/intel-core-i7-5960x-processor-extreme-edition-20m-cache-up-to-3-50-ghz.html")
+            result = arksearch.get_cpu_html(prodUrl)
         assert result == self.test_table
 
     def test_quick_search_multiple_results(self):


### PR DESCRIPTION
* Nowadays, Intel use "prodUrl"s instead of "quickUrl"s.
* update logic that extracts data from the table.
* some table test cases in `./tests/test_arksearch.py` should be updated (as I do not understand that old table's format)

Screenshots:
![image](https://user-images.githubusercontent.com/38759782/104736114-71ff0900-577d-11eb-9b8c-5890bc95aa68.png)

![image](https://user-images.githubusercontent.com/38759782/104736250-a246a780-577d-11eb-9c99-0fbb1f84c140.png)

